### PR TITLE
Add support for growlnotify and fg/bg detection in OSX

### DIFF
--- a/circe-notifications.el
+++ b/circe-notifications.el
@@ -127,7 +127,8 @@ notification."
                (string-equal "PRIVMSG" command))
               (when
                   (cond ((dolist (n circe-notifications-nicks-on-all-networks)
-                           (if (string-match n body)
+                           (if (or (string-match n body)
+                                   (string-match n channel))
                                (return t))))
                         ((member-ignore-case
                           nick
@@ -136,7 +137,7 @@ notification."
                           user
                           circe-notifications-watch-nicks)))
                 (when (circe-not-getting-spammed-by nick)
-                  (circe-notifications-notify nick body)))
+                  (circe-notifications-notify nick channel body)))
             ;; someone we are watching JOINed, PARTed, QUIT or was KICKed
             (when (and
                    channel
@@ -148,7 +149,7 @@ notification."
                            circe-notifications-watch-nicks))))
               (when (circe-not-getting-spammed-by nick)
                 (circe-notifications-notify
-                 nick (concat command ": " channel))))))))))
+                 nick channel command)))))))))
 
 
 (defun growl (title message)
@@ -166,7 +167,7 @@ notification."
   t)
 
 
-(defun circe-notifications-notify (nick body)
+(defun circe-notifications-notify (nick channel body)
   "Show a desktop notification with title NICK and body BODY."
     (cond ((string-equal circe-notifications-backend "dbus")
            (dbus-ignore-errors

--- a/circe-notifications.el
+++ b/circe-notifications.el
@@ -49,7 +49,8 @@
   :type '(choice
           (const :tag "Use dbus" "dbus")
           (const :tag "Use terminal-notifier" "terminal-notifier")
-          (const :tag "Use growlnotify" "growlnotify"))
+          (const :tag "Use growlnotify" "growlnotify")
+          (const :tag "Use OS X Notifications" "osx-notifications"))
   :group 'circe-notifications)
 
 (defcustom circe-notifications-wait-for 90
@@ -167,6 +168,18 @@ notification."
   t)
 
 
+(defun osx-notify (title channel message)
+  "Shows a native os x notification using applescript"
+  (flet ((encfn (s) (encode-coding-string s (keyboard-coding-system))) )
+    (start-process "osascript" nil
+                   "osascript"
+                   "-e"
+                   (format "display notification \"%s\" with title \"%s\" subtitle \"%s\""
+                           (encfn message)
+                           (encfn title)
+                           (encfn channel)))
+    t))
+
 (defun circe-notifications-notify (nick channel body)
   "Show a desktop notification with title NICK and body BODY."
     (cond ((string-equal circe-notifications-backend "dbus")
@@ -179,9 +192,12 @@ notification."
               :sound-name circe-notifications-sound-name
               :transient)))
           ((string-equal circe-notifications-backend "growlnotify")
-           (message "growling")
            (growl (xml-escape-string nick)
                   (xml-escape-string body)))
+          ((string-equal circe-notifications-backend "osx-notifications")
+           (osx-notify (xml-escape-string nick)
+                       (xml-escape-string channel)
+                       (xml-escape-string body)))
           (t
            (start-process "terminal-notifier"
                           "*terminal-notifier*"


### PR DESCRIPTION
Allows notifications to be sent using growl, which also works on 10.9+ (in a similar way to terminal-notifier.)

Also uses applescript to discover if emacs is in the background.
