### PR TITLE
Add notifications for highlighted strings by default

### DIFF
--- a/circe-notifications.el
+++ b/circe-notifications.el
@@ -193,7 +193,8 @@ the last message from NICK?"
   (interactive)
   (setq circe-notifications-watch-strings
         (append circe-notifications-watch-strings
-                (circe-notifications-nicks-on-all-networks)))
+                (circe-notifications-nicks-on-all-networks)
+                lui-highlight-keywords))
   (advice-add 'circe-display-PRIVMSG :after 'circe-notifications-PRIVMSG)
   (advice-add 'circe-display-channel-quit :after 'circe-notifications-QUIT)
   (advice-add 'circe-display-JOIN :after 'circe-notifications-JOIN)


### PR DESCRIPTION
Hi!

When I installed this package, I was a bit surprised that highlight keywords were not notified by default. This enables highlight of lui keywords by default.

If you don't feel like this is a good default, feel free to close this. I don't think a configuration option is a good idea since `(setq circe-notifications-watch-strings lui-highlight-keywords)` is easier than a config option.

Thanks for creating this package! :smile: 