### PR TITLE
Tweak workaround so alert-add-rule is only run once

### DIFF
--- a/circe-notifications.el
+++ b/circe-notifications.el
@@ -205,8 +205,9 @@ the last message from NICK?"
   ;; If alert-user-configuration is nil, the :style keyword is ignored.
   ;; Workaround for now is just to add a dummy rule that does nothing.
   ;; https://github.com/jwiegley/alert/issues/30
-  (if (eq alert-user-configuration nil)
-      (alert-add-rule :continue t)))
+  (unless (append alert-user-configuration
+                  alert-internal-configuration)
+    (alert-add-rule :continue t)))
 
 (defun disable-circe-notifications ()
   "Turn off notifications."


### PR DESCRIPTION
Per the readme, `enable-circe-notifications` is run repeatedly, even on reconnect. This is fine, however, this causes `alert-add-rule` to be rerun over and over if `alert-user-configuration` is nil. `alert-add-rule` changes `alert-internal-configuration`, so I tweaked the code so it only runs when both lists are empty.

Running `alert-add-rule` over and over causes `(alert "hello")` to trigger multiple notifications, at least for me, so this patch fixes that.

Also see https://github.com/jwiegley/alert/issues/30, which I wish was fixed by now 